### PR TITLE
Fix quasiQuicksort implementation

### DIFF
--- a/week-02/quasi-quicksort.hs
+++ b/week-02/quasi-quicksort.hs
@@ -1,6 +1,6 @@
 quasiQuicksort :: (Ord a) => [a] -> [a]
 quasiQuicksort [] = []
-quasiQuicksort (head:tail) = smaller ++ [pivot] ++ larger
+quasiQuicksort (head:tail) = sortedSmaller ++ [pivot] ++ sortedLargerOrEqual
                            where pivot = head
-                                 smaller = filter (< pivot) (quasiQuicksort tail)
-                                 larger = filter (> pivot) (quasiQuicksort tail)
+                                 sortedSmaller = quasiQuicksort $ filter (< pivot) tail
+                                 sortedLargerOrEqual = quasiQuicksort $ filter (>= pivot) tail


### PR DESCRIPTION
The quasiQuicksort implementation has two major issues that render it
unusable for educational purposes. This commit details and fixes those
issues.
- the main ideea of quicksort is that one can sort an array of elements
  by choosing a pivot, dividing the rest of the elements in two groups
  of which one contains elements lower than the pivot and the other
  elements at least as great as the pivot, sorting the two groups
  separately in a recursive manner and combining the two sorted groups
  and the pivot in a way that keeps the resulted array sorted.
  The current implementation is broken as, instead of relying on the
  divide-and-conquer approach of quicksort, it actually performs
  duplicated work by sorting all the elements (except the pivot) twice
  and only after that filtering the elements that are lower and
  respectively greater than the pivot. This minor implementation
  difference leads to exponential time complexity and makes the
  quasiQuicksort unusable for arrays with even a small number of
  elements e.g. on my machine it takes 54.84 seconds to sort a 25
  number array.
- when separating the array into groups of elements lower and greater
  than the pivot, the elements that are exactly equal to the pivot are
  lost. This can be easily fixed by allowing elements that are equal to
  the pivot to be part of one of the two groups.
